### PR TITLE
Update GameVersion, Mappings and OxygenFilter

### DIFF
--- a/Reactor.Template/Reactor.Template.csproj
+++ b/Reactor.Template/Reactor.Template.csproj
@@ -2,26 +2,26 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Version>1.0.0</Version>
-        <Mappings>NuclearPowered/Mappings:0.1.2</Mappings>
+        <Mappings>NuclearPowered/Mappings:0.2.0</Mappings>
 
         <Description>Mod template for Reactor</Description>
         <Authors>js6pak</Authors>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GamePlatform)' == 'Steam'">
-        <GameVersion>2020.12.9s</GameVersion>
+        <GameVersion>2021.3.5s</GameVersion>
         <DefineConstants>$(DefineConstants);STEAM</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GamePlatform)' == 'Itch'">
-        <GameVersion>2020.11.17i</GameVersion>
+        <GameVersion>2021.3.5i</GameVersion>
         <DefineConstants>$(DefineConstants);ITCH</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>
         <Deobfuscate Include="$(AmongUs)\BepInEx\plugins\Reactor-$(GameVersion).dll" />
 
-        <PackageReference Include="Reactor.OxygenFilter.MSBuild" Version="0.2.5" />
+        <PackageReference Include="Reactor.OxygenFilter.MSBuild" Version="0.2.9" />
     </ItemGroup>
 
     <Target Name="Copy" AfterTargets="Reobfuscate">


### PR DESCRIPTION
People getting 404 since `2020.12.9` mappings are deleted